### PR TITLE
Diff fixes: don't split emojis in half - check for deep equality when diffing

### DIFF
--- a/lib/quill_delta.dart
+++ b/lib/quill_delta.dart
@@ -483,7 +483,8 @@ class Delta {
   ///
   /// Useful when one wishes to display difference between 2 documents
   Delta diff(Delta other, {bool cleanupSemantic = true}) {
-    if (_operations.equals(other._operations)) {
+    if (_operations == other._operations ||
+        _valueEquality.equals(_operations, other._operations)) {
       return Delta();
     }
     final stringThis = map((op) {
@@ -531,7 +532,8 @@ class Delta {
             );
             final thisOp = thisIter.next(opLength);
             final otherOp = otherIter.next(opLength);
-            if (thisOp.data == otherOp.data) {
+            if (thisOp.data == otherOp.data ||
+                _valueEquality.equals(thisOp.data, otherOp.data)) {
               retDelta.retain(
                 opLength,
                 diffAttributes(thisOp.attributes, otherOp.attributes),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,6 +3,7 @@ description: Simple and expressive format for describing rich-text content creat
 version: 3.0.0-nullsafety.2
 homepage: https://github.com/pulyaevskiy/quill-delta-dart
 author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>
+publish_to: none
 
 environment:
   sdk: '>=2.12.0-0 <3.0.0'
@@ -10,7 +11,10 @@ environment:
 dependencies:
   collection: ^1.15.0
   quiver: ^3.0.0
-  diff_match_patch: ^0.4.1
+  diff_match_patch:
+    git:
+      url: https://github.com/superlistapp/diff-match-patch.git
+      ref: b756f70a5bb2a461a7e0f04aef28232d7f1a58f3
 
 dev_dependencies:
   coverage: ^1.0.0

--- a/test/quill_delta_test.dart
+++ b/test/quill_delta_test.dart
@@ -1342,6 +1342,58 @@ void main() {
         final expected = Delta()..retain(6)..insert('\n', {'index': 1.5});
         expect(a.diff(b), expected);
       });
+
+      test('replace an emoji with another emoji, where the first code unit of both is the same', () {
+        final a = Delta()..insert('\ud83d\udd35');
+        final b = Delta()..insert('\ud83d\udd34');
+        final expected = Delta()
+          ..insert('\ud83d\udd34')
+          ..delete(2);
+
+        expect(a.diff(b), expected);
+      });
+
+      test('replace an emoji with another emoji, where both code units are different', () {
+        final a = Delta()..insert('\ud83d\udc15');
+        final b = Delta()..insert('\ud83d\udd34');
+        final expected = Delta()
+          ..insert('\ud83d\udd34')
+          ..delete(2);
+
+        expect(a.diff(b), expected);
+      });
+
+      test('replace an emoji with another emoji with text before and after', () {
+        final a = Delta()..insert('ABC\ud83d\udd35123');
+        final b = Delta()..insert('ABC\ud83d\udd34123');
+        final expected = Delta()
+        ..retain(3)
+          ..insert('\ud83d\udd34')
+          ..delete(2);
+
+        expect(a.diff(b), expected);
+      });
+
+      test('replace an emoji with another emoji with text at the end of a sentence', () {
+        final a = Delta()..insert('ABC\ud83d\udd35');
+        final b = Delta()..insert('ABC\ud83d\udd34');
+        final expected = Delta()
+          ..retain(3)
+          ..insert('\ud83d\udd34')
+          ..delete(2);
+
+        expect(a.diff(b), expected);
+      });
+
+      test('replace an emoji with another emoji with text at the beginning of a sentence', () {
+        final a = Delta()..insert('\ud83d\udd35ABC');
+        final b = Delta()..insert('\ud83d\udd34ABC');
+        final expected = Delta()
+          ..insert('\ud83d\udd34')
+          ..delete(2);
+
+        expect(a.diff(b), expected);
+      });
     });
   });
 

--- a/test/quill_delta_test.dart
+++ b/test/quill_delta_test.dart
@@ -299,22 +299,16 @@ void main() {
       });
 
       test('retain', () {
-        final delta = Delta()
-          ..retain(2)
-          ..retain(3, {'b': true});
+        final delta = Delta()..retain(2)..retain(3, {'b': true});
         final base = Delta()..insert('123456');
-        final expected = Delta()
-          ..retain(2)
-          ..retain(3, {'b': null});
+        final expected = Delta()..retain(2)..retain(3, {'b': null});
         final inverted = delta.invert(base);
         expect(expected, inverted);
         expect(base.compose(delta).compose(inverted), base);
       });
 
       test('retain on a delta with different attributes', () {
-        final base = Delta()
-          ..insert('123')
-          ..insert('4', {'b': true});
+        final base = Delta()..insert('123')..insert('4', {'b': true});
         final delta = Delta()..retain(4, {'i': true});
         final expected = Delta()..retain(4, {'i': null});
         final inverted = delta.invert(base);
@@ -353,26 +347,20 @@ void main() {
       // ==== insert combinations ====
 
       test('insert + insert', () {
-        final delta = Delta()
-          ..insert('abc')
-          ..insert('123');
+        final delta = Delta()..insert('abc')..insert('123');
         expect(delta.first, Operation.insert('abc123'));
       });
 
       test('insert + insert (object)', () {
         const data = {};
-        final delta = Delta()
-          ..insert('abc')
-          ..insert(data);
+        final delta = Delta()..insert('abc')..insert(data);
         expect(delta[0], Operation.insert('abc'));
         expect(delta[1], Operation.insert(data));
       });
 
       test('insert (object) + insert', () {
         const data = {};
-        final delta = Delta()
-          ..insert(data)
-          ..insert('abc');
+        final delta = Delta()..insert(data)..insert('abc');
         expect(delta[0], Operation.insert(data));
         expect(delta[1], Operation.insert('abc'));
       });
@@ -428,9 +416,7 @@ void main() {
       });
 
       test('delete + delete', () {
-        final delta = Delta()
-          ..delete(2)
-          ..delete(3);
+        final delta = Delta()..delete(2)..delete(3);
         expect(delta.first, Operation.delete(5));
       });
 
@@ -469,18 +455,14 @@ void main() {
       });
 
       test('retain + retain', () {
-        final delta = Delta()
-          ..retain(2)
-          ..retain(3);
+        final delta = Delta()..retain(2)..retain(3);
         expect(delta.first, Operation.retain(5));
       });
 
       // ==== edge scenarios ====
 
       test('consequent inserts with different attributes do not merge', () {
-        final delta = Delta()
-          ..insert('abc', const {'b': true})
-          ..insert('123');
+        final delta = Delta()..insert('abc', const {'b': true})..insert('123');
         expect(delta.toList(), [
           Operation.insert('abc', const {'b': true}),
           Operation.insert('123'),
@@ -488,9 +470,7 @@ void main() {
       });
 
       test('consequent inserts (object) do not merge', () {
-        final delta = Delta()
-          ..insert(const {})
-          ..insert(const {});
+        final delta = Delta()..insert(const {})..insert(const {});
         expect(delta.toList(), [
           Operation.insert(const {}),
           Operation.insert(const {}),
@@ -519,9 +499,7 @@ void main() {
       });
 
       test('consequent retain with different attributes do not merge', () {
-        final delta = Delta()
-          ..retain(5, const {'b': true})
-          ..retain(3);
+        final delta = Delta()..retain(5, const {'b': true})..retain(3);
         expect(delta.toList(), [
           Operation.retain(5, const {'b': true}),
           Operation.retain(3),
@@ -568,9 +546,7 @@ void main() {
           ..delete(2)
           ..insert('YATA');
         final result = doc.compose(change);
-        final expected = Delta()
-          ..insert('YATAYATA')
-          ..insert(const {});
+        final expected = Delta()..insert('YATAYATA')..insert(const {});
         expect(result, expected);
       });
     });
@@ -587,18 +563,14 @@ void main() {
       test('insert + insert (object)', () {
         final a = Delta()..insert('A');
         final b = Delta()..insert(const {});
-        final expected = Delta()
-          ..insert(const {})
-          ..insert('A');
+        final expected = Delta()..insert(const {})..insert('A');
         expect(a.compose(b), expected);
       });
 
       test('insert (object) + insert', () {
         final a = Delta()..insert(const {});
         final b = Delta()..insert('B');
-        final expected = Delta()
-          ..insert('B')
-          ..insert(const {});
+        final expected = Delta()..insert('B')..insert(const {});
         expect(a.compose(b), expected);
       });
 
@@ -716,10 +688,7 @@ void main() {
         final b = Delta()
           ..retain(3)
           ..insert(const {});
-        final expected = Delta()
-          ..insert('Hel')
-          ..insert(const {})
-          ..insert('lo');
+        final expected = Delta()..insert('Hel')..insert(const {})..insert('lo');
         expect(a.compose(b), expected);
       });
 
@@ -1123,13 +1092,9 @@ void main() {
       });
 
       test('start and end multiple chop', () {
-        var slice = (Delta()
-              ..insert('0123', {'bold': true})
-              ..insert('4567'))
+        var slice = (Delta()..insert('0123', {'bold': true})..insert('4567'))
             .slice(3, 5);
-        var expected = Delta()
-          ..insert('3', {'bold': true})
-          ..insert('4');
+        var expected = Delta()..insert('3', {'bold': true})..insert('4');
         expect(slice, expected);
       });
 
@@ -1165,19 +1130,15 @@ void main() {
       });
 
       test('split ops', () {
-        var slice = (Delta()
-              ..insert('AB', {'bold': true})
-              ..insert('C'))
-            .slice(1, 2);
+        var slice =
+            (Delta()..insert('AB', {'bold': true})..insert('C')).slice(1, 2);
         var expected = Delta()..insert('B', {'bold': true});
         expect(slice, expected);
       });
 
       test('split ops multiple times', () {
-        var slice = (Delta()
-              ..insert('ABC', {'bold': true})
-              ..insert('D'))
-            .slice(1, 2);
+        var slice =
+            (Delta()..insert('ABC', {'bold': true})..insert('D')).slice(1, 2);
         var expected = Delta()..insert('B', {'bold': true});
         expect(slice, expected);
       });
@@ -1295,9 +1256,7 @@ void main() {
       });
 
       test('inconvenient indexes', () {
-        final a = Delta()
-          ..insert('12', {'b': true})
-          ..insert('34', {'i': true});
+        final a = Delta()..insert('12', {'b': true})..insert('34', {'i': true});
         final b = Delta()..insert('123', {'bg': 'red'});
         final expected = Delta()
           ..retain(2, {'b': null, 'bg': 'red'})
@@ -1337,9 +1296,7 @@ void main() {
       });
 
       test('same document', () {
-        final a = Delta()
-          ..insert('A')
-          ..insert('B', {'b': true});
+        final a = Delta()..insert('A')..insert('B', {'b': true});
         final expected = Delta();
         expect(a.diff(a), expected);
       });
@@ -1364,9 +1321,7 @@ void main() {
           ..insert('\n', {'index': 0.5})
           ..insert({'image': 'https://example.com/image.png'}, {'index': 1})
           ..insert('aaaaaa\n', {'index': 2});
-        final expected = Delta()
-          ..retain(5)
-          ..insert('\n', {'index': 0.5});
+        final expected = Delta()..retain(5)..insert('\n', {'index': 0.5});
         expect(a.diff(b), expected);
       });
 
@@ -1384,9 +1339,7 @@ void main() {
           ..insert({'image': 'https://example.com/image.png'}, {'index': 1})
           ..insert('\n', {'index': 1.5})
           ..insert('aaaaaa\n', {'index': 2});
-        final expected = Delta()
-          ..retain(6)
-          ..insert('\n', {'index': 1.5});
+        final expected = Delta()..retain(6)..insert('\n', {'index': 1.5});
         expect(a.diff(b), expected);
       });
     });
@@ -1407,12 +1360,7 @@ void main() {
 
     test('hasNext', () {
       expect(iterator.hasNext, isTrue);
-      iterator
-        ..next()
-        ..next()
-        ..next()
-        ..next()
-        ..next();
+      iterator..next()..next()..next()..next()..next();
       expect(iterator.hasNext, isFalse);
     });
 

--- a/test/quill_delta_test.dart
+++ b/test/quill_delta_test.dart
@@ -299,16 +299,22 @@ void main() {
       });
 
       test('retain', () {
-        final delta = Delta()..retain(2)..retain(3, {'b': true});
+        final delta = Delta()
+          ..retain(2)
+          ..retain(3, {'b': true});
         final base = Delta()..insert('123456');
-        final expected = Delta()..retain(2)..retain(3, {'b': null});
+        final expected = Delta()
+          ..retain(2)
+          ..retain(3, {'b': null});
         final inverted = delta.invert(base);
         expect(expected, inverted);
         expect(base.compose(delta).compose(inverted), base);
       });
 
       test('retain on a delta with different attributes', () {
-        final base = Delta()..insert('123')..insert('4', {'b': true});
+        final base = Delta()
+          ..insert('123')
+          ..insert('4', {'b': true});
         final delta = Delta()..retain(4, {'i': true});
         final expected = Delta()..retain(4, {'i': null});
         final inverted = delta.invert(base);
@@ -347,20 +353,26 @@ void main() {
       // ==== insert combinations ====
 
       test('insert + insert', () {
-        final delta = Delta()..insert('abc')..insert('123');
+        final delta = Delta()
+          ..insert('abc')
+          ..insert('123');
         expect(delta.first, Operation.insert('abc123'));
       });
 
       test('insert + insert (object)', () {
         const data = {};
-        final delta = Delta()..insert('abc')..insert(data);
+        final delta = Delta()
+          ..insert('abc')
+          ..insert(data);
         expect(delta[0], Operation.insert('abc'));
         expect(delta[1], Operation.insert(data));
       });
 
       test('insert (object) + insert', () {
         const data = {};
-        final delta = Delta()..insert(data)..insert('abc');
+        final delta = Delta()
+          ..insert(data)
+          ..insert('abc');
         expect(delta[0], Operation.insert(data));
         expect(delta[1], Operation.insert('abc'));
       });
@@ -416,7 +428,9 @@ void main() {
       });
 
       test('delete + delete', () {
-        final delta = Delta()..delete(2)..delete(3);
+        final delta = Delta()
+          ..delete(2)
+          ..delete(3);
         expect(delta.first, Operation.delete(5));
       });
 
@@ -455,14 +469,18 @@ void main() {
       });
 
       test('retain + retain', () {
-        final delta = Delta()..retain(2)..retain(3);
+        final delta = Delta()
+          ..retain(2)
+          ..retain(3);
         expect(delta.first, Operation.retain(5));
       });
 
       // ==== edge scenarios ====
 
       test('consequent inserts with different attributes do not merge', () {
-        final delta = Delta()..insert('abc', const {'b': true})..insert('123');
+        final delta = Delta()
+          ..insert('abc', const {'b': true})
+          ..insert('123');
         expect(delta.toList(), [
           Operation.insert('abc', const {'b': true}),
           Operation.insert('123'),
@@ -470,7 +488,9 @@ void main() {
       });
 
       test('consequent inserts (object) do not merge', () {
-        final delta = Delta()..insert(const {})..insert(const {});
+        final delta = Delta()
+          ..insert(const {})
+          ..insert(const {});
         expect(delta.toList(), [
           Operation.insert(const {}),
           Operation.insert(const {}),
@@ -499,7 +519,9 @@ void main() {
       });
 
       test('consequent retain with different attributes do not merge', () {
-        final delta = Delta()..retain(5, const {'b': true})..retain(3);
+        final delta = Delta()
+          ..retain(5, const {'b': true})
+          ..retain(3);
         expect(delta.toList(), [
           Operation.retain(5, const {'b': true}),
           Operation.retain(3),
@@ -546,7 +568,9 @@ void main() {
           ..delete(2)
           ..insert('YATA');
         final result = doc.compose(change);
-        final expected = Delta()..insert('YATAYATA')..insert(const {});
+        final expected = Delta()
+          ..insert('YATAYATA')
+          ..insert(const {});
         expect(result, expected);
       });
     });
@@ -563,14 +587,18 @@ void main() {
       test('insert + insert (object)', () {
         final a = Delta()..insert('A');
         final b = Delta()..insert(const {});
-        final expected = Delta()..insert(const {})..insert('A');
+        final expected = Delta()
+          ..insert(const {})
+          ..insert('A');
         expect(a.compose(b), expected);
       });
 
       test('insert (object) + insert', () {
         final a = Delta()..insert(const {});
         final b = Delta()..insert('B');
-        final expected = Delta()..insert('B')..insert(const {});
+        final expected = Delta()
+          ..insert('B')
+          ..insert(const {});
         expect(a.compose(b), expected);
       });
 
@@ -688,7 +716,10 @@ void main() {
         final b = Delta()
           ..retain(3)
           ..insert(const {});
-        final expected = Delta()..insert('Hel')..insert(const {})..insert('lo');
+        final expected = Delta()
+          ..insert('Hel')
+          ..insert(const {})
+          ..insert('lo');
         expect(a.compose(b), expected);
       });
 
@@ -1092,9 +1123,13 @@ void main() {
       });
 
       test('start and end multiple chop', () {
-        var slice = (Delta()..insert('0123', {'bold': true})..insert('4567'))
+        var slice = (Delta()
+              ..insert('0123', {'bold': true})
+              ..insert('4567'))
             .slice(3, 5);
-        var expected = Delta()..insert('3', {'bold': true})..insert('4');
+        var expected = Delta()
+          ..insert('3', {'bold': true})
+          ..insert('4');
         expect(slice, expected);
       });
 
@@ -1130,15 +1165,19 @@ void main() {
       });
 
       test('split ops', () {
-        var slice =
-            (Delta()..insert('AB', {'bold': true})..insert('C')).slice(1, 2);
+        var slice = (Delta()
+              ..insert('AB', {'bold': true})
+              ..insert('C'))
+            .slice(1, 2);
         var expected = Delta()..insert('B', {'bold': true});
         expect(slice, expected);
       });
 
       test('split ops multiple times', () {
-        var slice =
-            (Delta()..insert('ABC', {'bold': true})..insert('D')).slice(1, 2);
+        var slice = (Delta()
+              ..insert('ABC', {'bold': true})
+              ..insert('D'))
+            .slice(1, 2);
         var expected = Delta()..insert('B', {'bold': true});
         expect(slice, expected);
       });
@@ -1256,7 +1295,9 @@ void main() {
       });
 
       test('inconvenient indexes', () {
-        final a = Delta()..insert('12', {'b': true})..insert('34', {'i': true});
+        final a = Delta()
+          ..insert('12', {'b': true})
+          ..insert('34', {'i': true});
         final b = Delta()..insert('123', {'bg': 'red'});
         final expected = Delta()
           ..retain(2, {'b': null, 'bg': 'red'})
@@ -1296,7 +1337,9 @@ void main() {
       });
 
       test('same document', () {
-        final a = Delta()..insert('A')..insert('B', {'b': true});
+        final a = Delta()
+          ..insert('A')
+          ..insert('B', {'b': true});
         final expected = Delta();
         expect(a.diff(a), expected);
       });
@@ -1321,7 +1364,9 @@ void main() {
           ..insert('\n', {'index': 0.5})
           ..insert({'image': 'https://example.com/image.png'}, {'index': 1})
           ..insert('aaaaaa\n', {'index': 2});
-        final expected = Delta()..retain(5)..insert('\n', {'index': 0.5});
+        final expected = Delta()
+          ..retain(5)
+          ..insert('\n', {'index': 0.5});
         expect(a.diff(b), expected);
       });
 
@@ -1339,7 +1384,9 @@ void main() {
           ..insert({'image': 'https://example.com/image.png'}, {'index': 1})
           ..insert('\n', {'index': 1.5})
           ..insert('aaaaaa\n', {'index': 2});
-        final expected = Delta()..retain(6)..insert('\n', {'index': 1.5});
+        final expected = Delta()
+          ..retain(6)
+          ..insert('\n', {'index': 1.5});
         expect(a.diff(b), expected);
       });
     });
@@ -1360,7 +1407,12 @@ void main() {
 
     test('hasNext', () {
       expect(iterator.hasNext, isTrue);
-      iterator..next()..next()..next()..next()..next();
+      iterator
+        ..next()
+        ..next()
+        ..next()
+        ..next()
+        ..next();
       expect(iterator.hasNext, isFalse);
     });
 

--- a/test/quill_delta_test.dart
+++ b/test/quill_delta_test.dart
@@ -1306,6 +1306,42 @@ void main() {
         final b = Delta()..delete(4);
         expect(() => a.diff(b), throwsArgumentError);
       });
+
+      test('insert a block above an embed', () {
+        // We're adding "index: n" as attributes to make sure that each line
+        // stays separated. Without these attributes, the empty "\n" would be
+        // merged with the first paragraph.
+
+        final a = Delta()
+          ..insert('Test\n', {'index': 0})
+          ..insert({'image': 'https://example.com/image.png'}, {'index': 1})
+          ..insert('aaaaaa\n', {'index': 2});
+        final b = Delta()
+          ..insert('Test\n', {'index': 0})
+          ..insert('\n', {'index': 0.5})
+          ..insert({'image': 'https://example.com/image.png'}, {'index': 1})
+          ..insert('aaaaaa\n', {'index': 2});
+        final expected = Delta()..retain(5)..insert('\n', {'index': 0.5});
+        expect(a.diff(b), expected);
+      });
+
+      test('insert a block below an embed', () {
+        // We're adding "index: n" as attributes to make sure that each line
+        // stays separated. Without these attributes, the empty "\n" would be
+        // merged with the first paragraph.
+
+        final a = Delta()
+          ..insert('Test\n', {'index': 0})
+          ..insert({'image': 'https://example.com/image.png'}, {'index': 1})
+          ..insert('aaaaaa\n', {'index': 2});
+        final b = Delta()
+          ..insert('Test\n', {'index': 0})
+          ..insert({'image': 'https://example.com/image.png'}, {'index': 1})
+          ..insert('\n', {'index': 1.5})
+          ..insert('aaaaaa\n', {'index': 2});
+        final expected = Delta()..retain(6)..insert('\n', {'index': 1.5});
+        expect(a.diff(b), expected);
+      });
     });
   });
 


### PR DESCRIPTION
* Adds a fix for the case where emojis are "split in the middle" when diffing
* Adds deep equality checks for the operations in `Delta.diff()` - see longer explanation here https://github.com/pulyaevskiy/quill-delta-dart/pull/27